### PR TITLE
Bumps maven release plugin version from 2.3 to 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.3</version>
+          <version>2.4</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <!-- do not auto push release commits / tag -->


### PR DESCRIPTION
I ran into what looks like a bug with 2.3 which is resolved in 2.4:
- http://stackoverflow.com/questions/3291938/maven-release-plugin-ignores-releaseprofile
- http://jira.codehaus.org/browse/MRELEASE-459
- https://issues.apache.org/jira/browse/WINK-125
