### PR TITLE
Adds MR task progress indicators to nodes in graph view

### DIFF
--- a/common/src/main/resources/web/css/ambrose.css
+++ b/common/src/main/resources/web/css/ambrose.css
@@ -33,6 +33,6 @@ h2 { margin: 1em 0px; }
 /* Graph view */
 .ambrose-view-graph path.edge { fill: none; stroke: #aaa; stroke-width: 1.2px; }
 .ambrose-view-graph path.progress {}
-.ambrose-view-graph path.map { fill: #6D89D5; }
-.ambrose-view-graph path.reduce { fill: #FFB573; }
+.ambrose-view-graph path.map { fill: #0e90d2; }
+.ambrose-view-graph path.reduce { fill: #FF7800; }
 .ambrose-view-graph circle.magnitude { fill: rgba(28, 231, 231, 0.25); }

--- a/common/src/main/resources/web/js/modules/ambrose/view/core.js
+++ b/common/src/main/resources/web/js/modules/ambrose/view/core.js
@@ -20,14 +20,22 @@ limitations under the License.
 define(['lib/jquery', 'lib/d3', 'lib/colorbrewer', '../core'], function(
   $, d3, colorbrewer, Ambrose
 ) {
+  var pending = d3.rgb(0, 0, 0);
+  var running = d3.rgb(98, 196, 98).brighter();
+  var complete = d3.rgb('#eee');
+  var failed = d3.rgb(196, 98, 98);
+  var selected = d3.rgb(98, 98, 196).brighter();
+  var mouseover = selected.brighter();
+
   return Ambrose.View = {
     Theme: {
       colors: {
-        running: d3.rgb(98, 196, 98).brighter(),
-        complete: d3.rgb(196, 196, 196),
-        failed: d3.rgb(196, 98, 98),
-        mouseover: d3.rgb(98, 98, 196).brighter().brighter(),
-        selected: d3.rgb(98, 98, 196).brighter(),
+        pending: pending,
+        running: running,
+        complete: complete,
+        failed: failed,
+        selected: selected,
+        mouseover: mouseover,
       },
       palettes: {
         queued: colorbrewer.Greys,

--- a/common/src/main/resources/web/js/modules/ambrose/view/graph.js
+++ b/common/src/main/resources/web/js/modules/ambrose/view/graph.js
@@ -83,8 +83,8 @@ define(['lib/jquery', 'lib/d3', '../core', './core'], function(
           node: {
             radius: 8,
             progress: {
-              map: { radius: 11 },
-              reduce: { radius: 14 },
+              map: { radius: 12 },
+              reduce: { radius: 16 },
             },
             magnitude: {
               radius: {
@@ -337,7 +337,7 @@ define(['lib/jquery', 'lib/d3', '../core', './core'], function(
         var status = job.status || '';
         if (job.mouseover) return colors.mouseover;
         if (job.selected) return colors.selected;
-        return colors[status.toLowerCase()] || '#555';
+        return colors[status.toLowerCase()] || colors.pending;
       }
 
       var s = g.selectAll('g.node circle.anchor');


### PR DESCRIPTION
Map task progress is depicted with an arc around job node which grows from 9 o'clock to 3 o'clock around top of node. Reduce task progress is depicted the same way, but the arc grows around the bottom of the node.
