### PR TITLE
- Fix: Hive temp. output path resolution + removed some unnecessary concurrent data types usage

### DIFF
--- a/hive/src/main/java/com/twitter/ambrose/hive/AmbroseHivePreHook.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/AmbroseHivePreHook.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
 import org.apache.hadoop.hive.ql.hooks.HookContext;
 
+import com.google.common.collect.Maps;
 import com.twitter.ambrose.hive.reporter.EmbeddedAmbroseHiveProgressReporter;
 import com.twitter.ambrose.model.DAGNode;
 import com.twitter.ambrose.model.Event;
@@ -98,8 +99,7 @@ public class AmbroseHivePreHook implements ExecuteWithHookContext {
                 Thread.sleep(sleepTimeMs * 1000L);
                 
                 //send progressbar reset event
-                Map<WorkflowProgressField, String> eventData = 
-                  new HashMap<WorkflowProgressField, String>(1);
+                Map<WorkflowProgressField, String> eventData = Maps.newHashMapWithExpectedSize(1);
                 eventData.put(WorkflowProgressField.workflowProgress, "0");
                 reporter.pushEvent(queryId, new Event.WorkflowProgressEvent(eventData));
                 

--- a/hive/src/main/java/com/twitter/ambrose/hive/AmbroseHiveStatPublisher.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/AmbroseHiveStatPublisher.java
@@ -16,7 +16,6 @@ limitations under the License.
 package com.twitter.ambrose.hive;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -30,6 +29,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobID;
 import org.apache.hadoop.mapred.RunningJob;
 
+import com.google.common.collect.Maps;
 import com.twitter.ambrose.hive.reporter.EmbeddedAmbroseHiveProgressReporter;
 import com.twitter.ambrose.model.DAGNode;
 import com.twitter.ambrose.model.Event;
@@ -63,9 +63,7 @@ public class AmbroseHiveStatPublisher implements ClientStatsPublisher {
   private int totalReduceTasks;
   private int totalMapTasks;
 
-  private final Map<WorkflowProgressField, String> eventData = 
-    new HashMap<WorkflowProgressField, String>(1);
-
+  private final Map<WorkflowProgressField, String> eventData = Maps.newHashMapWithExpectedSize(1);
   private boolean init = true;
 
   private static class HiveMapReduceJobState extends MapReduceJobState {

--- a/hive/src/main/java/com/twitter/ambrose/hive/AmbroseHiveUtil.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/AmbroseHiveUtil.java
@@ -110,7 +110,7 @@ public class AmbroseHiveUtil {
 
   /**
    * Returns the nodeId of the given running job <br>
-   * E.g: Stage-1_[queryId]
+   * Example: Stage-1_[queryId]
    * 
    * @param conf
    * @param runningJob
@@ -150,7 +150,7 @@ public class AmbroseHiveUtil {
    * Gets the temporary directory of the given job
    * 
    * @param conf
-   * @param isLocal - true to resolve local temp. directory
+   * @param isLocal true to resolve local temporary directory
    * @return
    */
   public static String getJobTmpDir(Configuration conf, boolean isLocal) {

--- a/hive/src/main/java/com/twitter/ambrose/hive/HiveDAGTransformer.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/HiveDAGTransformer.java
@@ -19,13 +19,10 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,6 +40,9 @@ import org.apache.hadoop.hive.ql.plan.api.Adjacency;
 import org.apache.hadoop.hive.ql.plan.api.Graph;
 import org.apache.hadoop.hive.ql.plan.api.OperatorType;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.twitter.ambrose.model.DAGNode;
 import com.twitter.ambrose.model.Job;
 
@@ -107,7 +107,7 @@ public class HiveDAGTransformer {
   private void createNodeIdToDAGNode() {
 
     // creates DAGNodes: each node represents a MR job
-    nodeIdToDAGNode = new TreeMap<String, DAGNode<Job>>();
+    nodeIdToDAGNode = Maps.newTreeMap();
     for (Task<? extends Serializable> task : allTasks) {
       if (task.getWork() instanceof MapredWork) {
         DAGNode<Job> dagNode = asDAGNode(task);
@@ -123,8 +123,7 @@ public class HiveDAGTransformer {
       String nodeId = entry.getKey();
       List<String> successorIds = entry.getValue();
       DAGNode<Job> dagNode = nodeIdToDAGNode.get(nodeId);
-      List<DAGNode<? extends Job>> dagSuccessors = new ArrayList<DAGNode<? extends Job>>(
-          successorIds.size());
+      List<DAGNode<? extends Job>> dagSuccessors = Lists.newArrayListWithCapacity(successorIds.size());
 
       for (String sId : successorIds) {
         DAGNode<Job> successor = nodeIdToDAGNode.get(sId);
@@ -165,7 +164,7 @@ public class HiveDAGTransformer {
     if (indexTableAliases.isEmpty()) {
       return EMPTY_ARR;
     }
-    Set<String> result = new HashSet<String>();
+    Set<String> result = Sets.newLinkedHashSet();
     for (String alias : indexTableAliases) {
       //if alias is a temporary output location of an ancestor node
       if (alias.startsWith(tmpDir) || alias.startsWith(localTmpDir)) {
@@ -209,7 +208,7 @@ public class HiveDAGTransformer {
     if (ops == null) {
       return EMPTY_ARR;
     }
-    Set<String> features = new HashSet<String>();
+    Set<String> features = Sets.newHashSet();
     for (Operator<?> op : ops) {
       OperatorType opType = op.getType();
       // some operators are discarded
@@ -241,7 +240,7 @@ public class HiveDAGTransformer {
     if (pathToAliases == null || pathToAliases.isEmpty()) {
       return Collections.emptyList();
     }
-    List<String> result = new ArrayList<String>();
+    List<String> result = Lists.newArrayList();
     for (List<String> aliases : pathToAliases.values()) {
       if (aliases != null && !aliases.isEmpty()) {
         result.addAll(aliases);
@@ -256,7 +255,7 @@ public class HiveDAGTransformer {
    * @return
    */
   private Map<String, List<String>> getNodeIdToDependencies() {
-    Map<String, List<String>> result = new HashMap<String, List<String>>();
+    Map<String, List<String>> result = Maps.newHashMap();
     try {
       Graph stageGraph = queryPlan.getQueryPlan().getStageGraph();
       if (stageGraph == null) {
@@ -294,7 +293,7 @@ public class HiveDAGTransformer {
    */
   private List<String> getMRAdjacencies(List<String> adjChildren,
       Map<String, DAGNode<Job>> nodeIdToDAGNode) {
-    List<String> result = new ArrayList<String>();
+    List<String> result = Lists.newArrayList();
     for (String nodeName : adjChildren) {
       String nodeId = AmbroseHiveUtil.getNodeIdFromNodeName(conf, nodeName);
       if (nodeIdToDAGNode.containsKey(nodeId)) {

--- a/hive/src/main/java/com/twitter/ambrose/hive/HiveJob.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/HiveJob.java
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package com.twitter.ambrose.hive;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -26,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.Maps;
 import com.twitter.ambrose.model.Job;
 import com.twitter.ambrose.model.hadoop.CounterGroup;
 import com.twitter.ambrose.model.hadoop.MapReduceJobState;
@@ -95,7 +95,7 @@ public class HiveJob extends Job {
     counterGroupMap = AmbroseHiveUtil.counterGroupInfoMap(counterNameToValue);
 
     // job metrics
-    Map<String, Number> metrics = new HashMap<String, Number>();
+    Map<String, Number> metrics = Maps.newHashMap();
     metrics.put("numberMaps", totalMappers);
     metrics.put("numberReduces", totalReducers);
     metrics.put("avgMapTime",

--- a/hive/src/main/java/com/twitter/ambrose/hive/MetricsCounter.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/MetricsCounter.java
@@ -15,8 +15,8 @@ limitations under the License.
 */
 package com.twitter.ambrose.hive;
 
-import java.util.HashMap;
 import java.util.Map;
+import com.google.common.collect.Maps;
 
 /**
  * Lookup class that constructs Counter names to be retrieved from Hive
@@ -43,7 +43,7 @@ public enum MetricsCounter {
   REDUCE_INPUT_RECORDS(3),
   REDUCE_OUTPUT_RECORDS(3);
 
-  private static final Map<MetricsCounter, String[]> lookup = new HashMap<MetricsCounter, String[]>();
+  private static final Map<MetricsCounter, String[]> lookup = Maps.newHashMap();
   static {
     for (MetricsCounter hjc : MetricsCounter.values()) {
       lookup.put(hjc, createLookupKeys(hjc));

--- a/hive/src/main/java/com/twitter/ambrose/hive/TaskTag.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/TaskTag.java
@@ -15,8 +15,8 @@ limitations under the License.
 */
 package com.twitter.ambrose.hive;
 
-import java.util.HashMap;
 import java.util.Map;
+import com.google.common.collect.Maps;
 
 /**
  * Additional job properties
@@ -34,7 +34,7 @@ public enum TaskTag {
   LOCAL_MAPJOIN(5),
   MAPJOIN_ONLY_NOBACKUP(6);
 
-  private static final Map<Integer, String> lookup = new HashMap<Integer, String>();
+  private static final Map<Integer, String> lookup = Maps.newHashMap();
 
   static {
     for (TaskTag s : TaskTag.values()) {

--- a/hive/src/main/java/com/twitter/ambrose/hive/reporter/AmbroseHiveProgressReporter.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/reporter/AmbroseHiveProgressReporter.java
@@ -16,7 +16,6 @@ limitations under the License.
 package com.twitter.ambrose.hive.reporter;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,7 +31,6 @@ import org.apache.commons.logging.LogFactory;
 import com.twitter.ambrose.model.DAGNode;
 import com.twitter.ambrose.model.Event;
 import com.twitter.ambrose.model.Job;
-import com.twitter.ambrose.model.Event.WorkflowProgressField;
 import com.twitter.ambrose.service.StatsWriteService;
 
 /**

--- a/hive/src/test/java/com/twitter/ambrose/model/HiveJobTest.java
+++ b/hive/src/test/java/com/twitter/ambrose/model/HiveJobTest.java
@@ -21,13 +21,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.Maps;
 import com.twitter.ambrose.hive.HiveJob;
 
 /**
@@ -42,7 +42,7 @@ public class HiveJobTest {
 
   @Before
   public void setUp() throws Exception {
-    Map<String, Number> metrics = new HashMap<String, Number>();
+    Map<String, Number> metrics = Maps.newHashMapWithExpectedSize(1);
     metrics.put("somemetric", 6);
     Properties properties = new Properties();
     properties.setProperty("someprop", "propvalue");
@@ -74,15 +74,29 @@ public class HiveJobTest {
 
   @Test
   public void testFromJson() throws IOException {
-    String json = "{" + "  \"type\" : \"JOB_STARTED\"," + "  \"payload\" : {"
-        + "    \"name\" : \"Stage-1_user_20130723105858_3f0d530c-34a6-4bb9-8964-22c4ea289895\","
-        + "    \"job\" : {" + "      \"runtime\" : \"hive\","
-        + "      \"id\" : \"job_201307231015_0004 (Stage-1, query-id: ...22c4ea289895)\","
-        + "      \"aliases\" : [ \"src\" ]," + "      \"features\" : [ \"SELECT\", \"FILTER\" ]"
-        + "    }," + "    \"successorNames\" : [ ]" + "  }," + "  \"id\" : 1,"
-        + "  \"timestamp\" : 1374569908714" + "}, {" + "  \"type\" : \"WORKFLOW_PROGRESS\","
-        + "  \"payload\" : {" + "    \"workflowProgress\" : \"0\"" + "  }," + "  \"id\" : 2,"
-        + "  \"timestamp\" : 1374569908754" + "}";
+    String json = 
+      "{" +
+      "  \"type\" : \"JOB_STARTED\"," +
+      "  \"payload\" : {" +
+      "    \"name\" : \"Stage-1_user_20130723105858_3f0d530c-34a6-4bb9-8964-22c4ea289895\"," +
+      "    \"job\" : {" +
+      "      \"runtime\" : \"hive\"," +
+      "      \"id\" : \"job_201307231015_0004 (Stage-1, query-id: ...22c4ea289895)\"," +
+      "      \"aliases\" : [ \"src\" ]," +
+      "      \"features\" : [ \"SELECT\", \"FILTER\" ]" +
+      "    }," +
+      "    \"successorNames\" : [ ]" +
+      "  }," +
+      "  \"id\" : 1," +
+      "  \"timestamp\" : 1374569908714" +
+      "}, {" +
+      "  \"type\" : \"WORKFLOW_PROGRESS\"," +
+      "  \"payload\" : {" +
+      "    \"workflowProgress\" : \"0\"" +
+      "  }," +
+      "  \"id\" : 2," +
+      "  \"timestamp\" : 1374569908754" +
+      "}";
 
     Event<?> event = Event.fromJson(json);
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Hive job aliases may refer to temporary output locations instead of tables in the query.
(reference: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Explain)
This is the case if the job's input is an ancestor node's (job) output.
To identify such a job, the aliases are checked, whether they start with the temp. output path. If so,
'temp. intermediate data' is shown on the GUI.
The fix handles some cases when the temp. output path was wrongly constructed therefore aliases were
remained the default 'N/A' instead of 'temp. intermediate data'.
