### PR TITLE
Show elapsed time support for Ambrose-Hive

### DIFF
--- a/hive/src/main/demo/demo.q
+++ b/hive/src/main/demo/demo.q
@@ -1,5 +1,4 @@
--- Demo Hive script for use with hive-ambrose,  based on the test case
--- https://svn.apache.org/repos/asf/hive/branches/branch-0.11/ql/src/test/queries/clientpositive/union28.q
+-- Demo Hive script for use with hive-ambrose
 -- 
 -- To run in mapreduce mode, copy demo folder to hdfs:
 -- 
@@ -13,11 +12,9 @@
 -- -Dambrose.write.dag.file=jobs.json \
 -- -Dambrose.write.events.file=events.json"
 -- 
---
 
-SET hive.auto.convert.join = true;
 SET hive.exec.parallel=true;
-SET hive.exec.parallel.thread.number=4;
+SET hive.exec.parallel.thread.number=2;
 SET mapred.reduce.tasks=4;
 
 DROP TABLE IF EXISTS ambrose_hive_demo;
@@ -28,13 +25,28 @@ CREATE EXTERNAL TABLE ambrose_hive_demo (key STRING, value STRING)
   STORED AS TEXTFILE
   LOCATION '/demo/input';
 
+DROP VIEW IF EXISTS ambrose_hive_demo_view1;
+CREATE VIEW ambrose_hive_demo_view1 as 
+  select v1q.key as key, v1q.value as value from (
+    select v1q1.key, v1q1.value from ambrose_hive_demo v1q1 group by v1q1.key, v1q1.value 
+    union all 
+    select v1q2.key, v1q2.value from ambrose_hive_demo v1q2 group by v1q2.key, v1q2.value
+  ) v1q;
+
+DROP VIEW IF EXISTS ambrose_hive_demo_view2;
+CREATE VIEW ambrose_hive_demo_view2 as 
+  select v2q.key as key, v2q.value as value from (
+    select v2q1.key, v2q2.value from ambrose_hive_demo v2q1 
+      left outer join ambrose_hive_demo v2q2 on (v2q1.key = v2q2.key) 
+    union all 
+    select v2q2.key, v2q3.value from ambrose_hive_demo v2q2 
+      left outer join ambrose_hive_demo v2q3 on (v2q2.key = v2q3.key)
+  ) v2q;
+
 select * from (
-  select key, value from ambrose_hive_demo 
-  union all 
-  select key, value from 
-  (
-    select key, value, count(1) from ambrose_hive_demo group by key, value
-    union all
-    select key, value, count(1) from ambrose_hive_demo group by key, value
-  ) subq
-) a;
+  select view1.key, view2.value from (
+    select view1a.key, view1b.value from ambrose_hive_demo_view1 view1a
+      cross join ambrose_hive_demo_view1 view1b on view1a.key = view1b.key) view1
+    join
+    ambrose_hive_demo_view2 view2 on (view1.key=view2.key)
+) q limit 5;

--- a/hive/src/main/java/com/twitter/ambrose/hive/HiveDAGTransformer.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/HiveDAGTransformer.java
@@ -65,7 +65,9 @@ public class HiveDAGTransformer {
   private static final Pattern SUBQUERY_ALIAS = Pattern.compile("-subquery\\d+\\:([^\\-]+)");
   private static final String PENDING_JOB = "N/A";
   private static final String TEMP_JOB_ID = "temp. intermediate data";
-
+  private static final String INTERNAL_HIVE_JOIN_ALIAS = "$INTNAME";
+  private static final String INTERNAL_JOIN_ALIAS = "internal";
+  
   private final String tmpDir;
   private final String localTmpDir;
   private final QueryPlan queryPlan;
@@ -169,6 +171,10 @@ public class HiveDAGTransformer {
       //if alias is a temporary output location of an ancestor node
       if (alias.startsWith(tmpDir) || alias.startsWith(localTmpDir)) {
         result.add(TEMP_JOB_ID);
+      }
+      //in case of an internal join alias
+      else if (alias.startsWith(INTERNAL_HIVE_JOIN_ALIAS)) {
+        result.add(alias.replace(INTERNAL_HIVE_JOIN_ALIAS, INTERNAL_JOIN_ALIAS));
       }
       else if (alias.contains("subquery")) {
         Matcher m = SUBQUERY_ALIAS.matcher(alias);

--- a/hive/src/main/java/com/twitter/ambrose/hive/HiveJob.java
+++ b/hive/src/main/java/com/twitter/ambrose/hive/HiveJob.java
@@ -59,10 +59,11 @@ public class HiveJob extends Job {
   }
 
   @JsonCreator
-  public HiveJob(@JsonProperty("id") String id, @JsonProperty("aliases") String[] aliases,
-      @JsonProperty("features") String[] features,
-      @JsonProperty("mapReduceJobState") MapReduceJobState mapReduceJobState,
-      @JsonProperty("counterGroupMap") Map<String, CounterGroup> counterGroupMap) {
+  public HiveJob(@JsonProperty("id") String id,
+                 @JsonProperty("aliases") String[] aliases,
+                 @JsonProperty("features") String[] features,
+                 @JsonProperty("mapReduceJobState") MapReduceJobState mapReduceJobState,
+                 @JsonProperty("counterGroupMap") Map<String, CounterGroup> counterGroupMap) {
     this(aliases, features);
     setId(id);
     this.mapReduceJobState = mapReduceJobState;
@@ -85,6 +86,10 @@ public class HiveJob extends Job {
     this.mapReduceJobState = mapReduceJobState;
   }
 
+  public Map<String, CounterGroup> getCounterGroupMap() {
+    return counterGroupMap;
+  }
+
   public CounterGroup getCounterGroupInfo(String name) {
     return counterGroupMap == null ? null : counterGroupMap.get(name);
   }
@@ -100,7 +105,7 @@ public class HiveJob extends Job {
     metrics.put("numberReduces", totalReducers);
     metrics.put("avgMapTime",
         getAvgCounterValue(counterNameToValue, MetricsCounter.SLOTS_MILLIS_MAPS, totalMappers));
-   metrics.put("avgReduceTime",
+    metrics.put("avgReduceTime",
        getAvgCounterValue(counterNameToValue, MetricsCounter.SLOTS_MILLIS_REDUCES, totalReducers));
     metrics.put("bytesWritten",
         getCounterValue(counterNameToValue, MetricsCounter.FILE_BYTES_WRITTEN));

--- a/hive/src/test/java/com/twitter/ambrose/model/HiveJobTest.java
+++ b/hive/src/test/java/com/twitter/ambrose/model/HiveJobTest.java
@@ -83,7 +83,10 @@ public class HiveJobTest {
       "      \"runtime\" : \"hive\"," +
       "      \"id\" : \"job_201307231015_0004 (Stage-1, query-id: ...22c4ea289895)\"," +
       "      \"aliases\" : [ \"src\" ]," +
-      "      \"features\" : [ \"SELECT\", \"FILTER\" ]" +
+      "      \"features\" : [ \"SELECT\", \"FILTER\" ]," +
+      "      \"metrics\" : {\n" +
+      "        \"somemetric\": 123\n" +
+      "      } \n" +
       "    }," +
       "    \"successorNames\" : [ ]" +
       "  }," +
@@ -104,6 +107,8 @@ public class HiveJobTest {
     assertEquals("job_201307231015_0004 (Stage-1, query-id: ...22c4ea289895)", job.getId());
     assertArrayEquals(new String[] { "src" }, job.getAliases());
     assertArrayEquals(new String[] { "SELECT", "FILTER" }, job.getFeatures());
+    assertNotNull(job.getMetrics());
+    assertEquals(123, job.getMetrics().get("somemetric"));
   }
 
   private void doTestRoundTrip(DAGNode<HiveJob> expected) throws IOException {


### PR DESCRIPTION
The elapsed time feature didn't work for Hive runtime. AmbroseHiveStatPublisher now
instantiates MapReduceJobState with args where the elapsed time is initialized/maintained.
Further fixes/improvements:
- counterGroupMap was missing from event file
- new demo example (has more pretty DAG)
- resolve internal join alias name
- HiveJobTest: add testing metrics in event json
- minor indentation issues
