### PR TITLE
[Bug Fix] Able to flip to next page even if there is no more jobs

### DIFF
--- a/common/src/main/resources/web/js/modules/ambrose/dashboard.js
+++ b/common/src/main/resources/web/js/modules/ambrose/dashboard.js
@@ -63,8 +63,12 @@ define(['lib/jquery', './core', './client'], function($, Ambrose, Client) {
       $('#user-form').submit(function() {
         self.setUser($('#user-field').val()); self.loadFlows(); return false;
       });
-      $('#page-prev-link').click(function() { self.prevPage(); });
-      $('#page-next-link').click(function() { self.nextPage(); });
+      $('#page-prev-link').click(function() {
+        if (!$('#page-prev-link').hasClass("disabled")) { self.prevPage(); }
+      });
+      $('#page-next-link').click(function() {
+        if (!$('#page-next-link').hasClass("disabled")) { self.nextPage(); }
+      });
 
       // set default values
       self.setStatus('running');
@@ -185,9 +189,9 @@ define(['lib/jquery', './core', './client'], function($, Ambrose, Client) {
         $('#page-next-link').addClass('disabled');
       }
       if (self.prevStartKeys.length > 0) {
-        $('#page-next-link').removeClass('disabled');
+        $('#page-prev-link').removeClass('disabled');
       } else {
-        $('#page-next-link').addClass('disabled');
+        $('#page-prev-link').addClass('disabled');
       }
       return this;
     },


### PR DESCRIPTION
It seems that the buttons are still clickable even if the class "disabled" is toggled on. Added checks to handle that and fixed the typo in the code.
