### PR TITLE
Fix the dashboard status change bug.

### DIFF
--- a/common/src/main/resources/web/js/modules/ambrose/dashboard.js
+++ b/common/src/main/resources/web/js/modules/ambrose/dashboard.js
@@ -54,7 +54,13 @@ define(['lib/jquery', './core', './client'], function($, Ambrose, Client) {
             .attr('id', 'status_' + id).addClass('status'))
           .text(id)
           .click(function() {
+            // Reset the keys and status when clicked on a different status.
+            self.currentStartKey = '';
+            self.nextStartKey = '';
+            self.prevStartKeys = [];
             self.setStatus(id);
+
+            // Get the workflows
             self.loadFlows();
           });
       });


### PR DESCRIPTION
The bug is that when the user flipped a page in the dashboard, the currentStartKey is updated. 
After this action, if the user tries to view jobs with different status, loadFlows() will return nothing.

Fixed by re-initialized the tracking variables.
