### PR TITLE
Cleans up poms

### DIFF
--- a/cascading/pom.xml
+++ b/cascading/pom.xml
@@ -76,20 +76,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>make-assembly</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <descriptors>
-                <descriptor>src/main/assembly/bin.xml</descriptor>
-              </descriptors>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -52,20 +52,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>make-assembly</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <descriptors>
-                <descriptor>src/main/assembly/bin.xml</descriptor>
-              </descriptors>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -247,21 +247,18 @@
       </dependency>
 
       <!-- scalding -->
-         
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-compiler</artifactId>
         <version>${scala.version}</version>
         <scope>compile</scope>
       </dependency>
-
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
         <version>${scala.version}</version>
         <scope>provided</scope>
       </dependency>
-
      <dependency>
        <groupId>com.twitter</groupId>
        <artifactId>scalding-core_2.9.3</artifactId>
@@ -288,6 +285,7 @@
           <configuration>
             <source>1.6</source>
             <target>1.6</target>
+            <showDeprecation>true</showDeprecation>
             <optimize>true</optimize>
           </configuration>
         </plugin>
@@ -310,6 +308,44 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.12</version>
+        </plugin>
+
+        <!-- scala compilation; by default scala compiled before java -->
+        <plugin>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <version>3.0.1</version>
+          <configuration>
+            <displayCmd>true</displayCmd>
+            <args>
+              <param>-unchecked</param>
+              <param>-deprecation</param>
+              <param>-encoding</param>
+              <param>utf8</param>
+            </args>
+          </configuration>
+          <executions>
+            <execution>
+              <id>scala-add-sources</id>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>scala-main-compile</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>scala-test-compile</id>
+              <phase>process-test-resources</phase>
+              <goals>
+                <goal>testCompile</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- package types -->
@@ -340,6 +376,20 @@
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>2.3</version>
+          <executions>
+            <execution>
+              <id>make-assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+              <configuration>
+                <descriptors>
+                  <descriptor>src/main/assembly/bin.xml</descriptor>
+                </descriptors>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>

--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -13,6 +13,14 @@
   <artifactId>ambrose-scalding</artifactId>
   <name>Ambrose Scalding</name>
 
+  <!--
+
+    The following repo hosts the work-in-progress cascading deps required by the ambrose-cascading
+    module.
+
+    TODO(Andy Schlaikjer): Remove this once updates to cascading hit maven central.
+
+  -->
   <repositories>
     <repository>
       <id>conjars.org</id>
@@ -20,98 +28,48 @@
     </repository>
   </repositories>
 
-
   <dependencies>
     <!-- ambrose -->
-
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ambrose-cascading</artifactId>
     </dependency>
 
-     <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scala-compiler</artifactId>
-     </dependency>
-
-     <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scala-library</artifactId>
-     </dependency>
-
+    <!-- scala -->
     <dependency>
-       <groupId>com.twitter</groupId>
-       <artifactId>scalding-core_2.9.3</artifactId>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-compiler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
     </dependency>
 
+    <!-- scalding -->
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>scalding-core_2.9.3</artifactId>
+    </dependency>
+
+    <!-- hadoop -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapred</artifactId>
     </dependency>
-
-
   </dependencies>
 
   <build>
     <plugins>
+
+      <!-- compile scala -->
       <plugin>
-          <groupId>net.alchim31.maven</groupId>
-          <artifactId>scala-maven-plugin</artifactId>
-          <version>3.0.1</version>
-        <executions>
-          <execution>
-            <id>scala-compile-first</id>
-            <phase>process-resources</phase>
-            <configuration>
-              <args>
-                <param>-unchecked</param>
-                <param>-deprecation</param>
-                <param>-encoding</param>
-                <param>utf8</param>
-              </args>
-            </configuration>
-            <goals>
-              <goal>add-source</goal>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>scala-test-compile</id>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <args>
-                <param>-unchecked</param>
-                <param>-deprecation</param>
-                <param>-encoding</param>
-                <param>utf8</param>
-              </args>
-            </configuration>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
       </plugin>
 
+      <!-- compile java -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
-            <showDeprecation>true</showDeprecation>
-            <showWarnings>true</showWarnings>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
-
+	<artifactId>maven-compiler-plugin</artifactId>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
I've updated some of the plugin management within the parent `pom.xml` to simplify child module `pom.xml`s.

Tested manually with various invocations of `mvn compile`, `mvn package` to verify behavior remains consistent with master.
