### PR TITLE
Avoid NPE in API handler when dagnodemap is absent in the backend for a ...

### DIFF
--- a/common/src/main/java/com/twitter/ambrose/server/APIHandler.java
+++ b/common/src/main/java/com/twitter/ambrose/server/APIHandler.java
@@ -8,6 +8,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 
@@ -139,7 +140,10 @@ public class APIHandler extends AbstractHandler {
       LOG.info("Submitted request for workflowId={}", workflowId);
       Map<String, DAGNode<Job>> dagNodeNameMap =
           statsReadService.getDagNodeNameMap(workflowId);
-      Collection<DAGNode<Job>> nodes = dagNodeNameMap.values();
+      Collection<DAGNode<Job>> nodes = Lists.newArrayList();
+      if (dagNodeNameMap != null) {
+        nodes = dagNodeNameMap.values();
+      }
 
       response.setContentType(MIME_TYPE_JSON);
       response.setStatus(HttpServletResponse.SC_OK);


### PR DESCRIPTION
...given workflow
