### PR TITLE
Add default to list of clusters for corner cases

### DIFF
--- a/common/src/main/java/com/twitter/ambrose/service/impl/hraven/HRavenWorkflowIndexReadService.java
+++ b/common/src/main/java/com/twitter/ambrose/service/impl/hraven/HRavenWorkflowIndexReadService.java
@@ -65,6 +65,7 @@ public class HRavenWorkflowIndexReadService implements WorkflowIndexReadService 
     //TODO make this an api in hraven
     Properties props = new Properties();
     String filename = Constants.HRAVEN_CLUSTER_PROPERTIES_FILENAME;
+    clusterMap.put("default", "default");
     try {
       //TODO : property file to be moved out from resources into config dir
       InputStream inp = Cluster.class.getResourceAsStream("/" + filename);


### PR DESCRIPTION
https://github.com/twitter/ambrose/blob/master/common/src/main/java/com/twitter/ambrose/service/impl/hraven/HRavenStatsWriteService.java#L302 puts default as clustername for failure cases. Workflow service should support that.
