### PR TITLE
bump cascading version, remove empty jar dep

### DIFF
--- a/cascading/pom.xml
+++ b/cascading/pom.xml
@@ -66,10 +66,6 @@
       <groupId>cascading</groupId>
       <artifactId>cascading-xml</artifactId>
     </dependency>
-    <dependency>
-      <groupId>cascading</groupId>
-      <artifactId>cascading-platform</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <apache.hbase.version>0.94.0</apache.hbase.version>
     <mortbay.jetty.version>6.1.25</mortbay.jetty.version>
     <mortbay.jetty.servlet.version>2.5-20081211</mortbay.jetty.servlet.version>
-    <cascading.version>2.5.2</cascading.version>
+    <cascading.version>2.5.4</cascading.version>
     <twitter.hraven.version>0.9.13</twitter.hraven.version>
     <scalding.version>0.9.1</scalding.version>
     <scala.version>2.9.2</scala.version>
@@ -251,12 +251,6 @@
       <dependency>
         <groupId>cascading</groupId>
         <artifactId>cascading-xml</artifactId>
-        <version>${cascading.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>cascading</groupId>
-        <artifactId>cascading-platform</artifactId>
         <version>${cascading.version}</version>
         <scope>provided</scope>
       </dependency>


### PR DESCRIPTION
1. Dump cascading version up to `2.5.4`
2. Remove `cascading-platform` dependency. The jar is empty except for a MANIFEST file.
