### PR TITLE
Add shutdown method to StatsWriteService

### DIFF
--- a/cascading/src/main/java/com/twitter/ambrose/cascading/AmbroseCascadingNotifier.java
+++ b/cascading/src/main/java/com/twitter/ambrose/cascading/AmbroseCascadingNotifier.java
@@ -22,10 +22,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import com.google.common.collect.Maps;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.mapred.JobClient;
 import org.jgrapht.graph.SimpleDirectedGraph;
+
+import com.twitter.ambrose.model.DAGNode;
+import com.twitter.ambrose.model.Event;
+import com.twitter.ambrose.model.Job;
+import com.twitter.ambrose.model.hadoop.MapReduceHelper;
+import com.twitter.ambrose.service.StatsWriteService;
+import com.twitter.ambrose.util.AmbroseUtils;
 
 import cascading.flow.Flow;
 import cascading.flow.FlowListener;
@@ -35,14 +44,6 @@ import cascading.flow.Flows;
 import cascading.flow.hadoop.HadoopFlowStep;
 import cascading.flow.planner.BaseFlowStep;
 import cascading.stats.hadoop.HadoopStepStats;
-
-import com.google.common.collect.Maps;
-import com.twitter.ambrose.model.DAGNode;
-import com.twitter.ambrose.model.Event;
-import com.twitter.ambrose.model.Job;
-import com.twitter.ambrose.model.hadoop.MapReduceHelper;
-import com.twitter.ambrose.service.StatsWriteService;
-import com.twitter.ambrose.util.AmbroseUtils;
 
 /**
  * CascadingNotifier that collects plan and job information from within a cascading
@@ -130,7 +131,13 @@ public class AmbroseCascadingNotifier implements FlowListener, FlowStepListener 
    * @param flow
    */
   @Override
-  public void onCompleted(Flow flow) {}
+  public void onCompleted(Flow flow) {
+    try {
+      statsWriteService.shutdownWriteService();
+    } catch (IOException e) {
+      log.warn("Failure trying to shutdown the StatsWriteService" + e);
+    }
+  }
 
   /**
    * The onThrowable event is fired if any child

--- a/common/src/main/java/com/twitter/ambrose/service/StatsWriteService.java
+++ b/common/src/main/java/com/twitter/ambrose/service/StatsWriteService.java
@@ -15,13 +15,13 @@ limitations under the License.
 */
 package com.twitter.ambrose.service;
 
-import com.twitter.ambrose.model.DAGNode;
-import com.twitter.ambrose.model.Event;
-import com.twitter.ambrose.model.Job;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
+
+import com.twitter.ambrose.model.DAGNode;
+import com.twitter.ambrose.model.Event;
+import com.twitter.ambrose.model.Job;
 
 /**
  * Service that accepts the DAGNode map and push events. Implementations of this service might write
@@ -55,4 +55,10 @@ public interface StatsWriteService<T extends Job> {
    * @param event the event bound to the workflow
    */
   public void pushEvent(String workflowId, Event event) throws IOException;
+
+  /**
+   * Perform any shutdown/cleanup required when this StatWriteService is no longer required.
+   * @throws IOException
+   */
+  public void shutdownWriteService() throws IOException;
 }

--- a/common/src/main/java/com/twitter/ambrose/service/impl/InMemoryStatsService.java
+++ b/common/src/main/java/com/twitter/ambrose/service/impl/InMemoryStatsService.java
@@ -25,14 +25,15 @@ import java.util.Properties;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.twitter.ambrose.model.DAGNode;
 import com.twitter.ambrose.model.Event;
 import com.twitter.ambrose.model.Job;
@@ -131,6 +132,9 @@ public class InMemoryStatsService implements StatsReadService, StatsWriteService
     }
     writeJsonEventToDisk(event);
   }
+
+  @Override
+  public void shutdownWriteService() throws IOException {} // no-op for in-memory
 
   @Override
   public synchronized Map<String, DAGNode<Job>> getDagNodeNameMap(String workflowId) {

--- a/common/src/main/java/com/twitter/ambrose/service/impl/hraven/HRavenStatsWriteService.java
+++ b/common/src/main/java/com/twitter/ambrose/service/impl/hraven/HRavenStatsWriteService.java
@@ -130,7 +130,7 @@ public class HRavenStatsWriteService implements StatsWriteService {
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
       public void run() {
-        shutdown();
+        shutdownWriteService();
       }
     });
   }
@@ -250,7 +250,8 @@ public class HRavenStatsWriteService implements StatsWriteService {
         && dagNodeNameMap != null;
   }
 
-  public void shutdown() {
+  @Override
+  public void shutdownWriteService() {
     if (shutdown) {
       return;
     }
@@ -399,11 +400,6 @@ public class HRavenStatsWriteService implements StatsWriteService {
     }
 
     hRavenPool.submit(new HRavenEventRunnable(flowEventService, flowEvent));
-  }
-
-  @Override
-  public void shutdownWriteService() throws IOException {
-    shutdown();
   }
 
   private void updateFlowQueue(FlowQueueKey key) throws IOException {


### PR DESCRIPTION
Currently, a cascading driver program that is integrated with an ambrose listener never actually terminates. The only way to shutdown an `HRaveStatsWriteService` is via a shutdown hook, eg

``` java
    Runtime.getRuntime().addShutdownHook(new Thread() {
      @Override
      public void run() {
        shutdown();
      }
    });
```

This works in pig, which explicitly calls `System.exit(run(...))` where `run` drives the entire pig program. Scalding does not have such an explicit `System.exit`, so the executor pool hangs forever waiting for instructions. 

This PR adds a `StatsWriteService#shutdownWriteService` method to gracefully shutdown the write service. Add a call to this method in the cascading `onComplete` method, which is called when all work for the flow is finished.
