### PR TITLE
Fixed problem where `./bin/ambrose-demo` did not work 

### DIFF
--- a/common/src/main/resources/web/js/modules/ambrose/core.js
+++ b/common/src/main/resources/web/js/modules/ambrose/core.js
@@ -94,12 +94,15 @@ define(['lib/jquery'], function($) {
   // core Ambrose object, util methods
   return {
     parseHRavenWorkflow : function(workflow) {
-      var splits = workflow.id.split("!");
+      var splits = [];
       var info = {};
-      if (splits.length == 6) {
-        info.cluster = splits[0];
-        info.user = splits[1];
-        info.id = splits[2];
+      if ('undefined' !== typeof workflow.id) {
+        splits = workflow.id.split("!");
+        if (splits.length == 6) {
+          info.cluster = splits[0];
+          info.user = splits[1];
+          info.id = splits[2];
+        }
       }
       return info;
     },


### PR DESCRIPTION
Fixed problem where `./bin/ambrose-demo` did not work because `workflow.id` was undefined.

I'm not a javascript ace, so happy to hear feedback it the solution could be better.
