### PR TITLE
Removes unused cascading-xml dependency

### DIFF
--- a/cascading/pom.xml
+++ b/cascading/pom.xml
@@ -60,10 +60,6 @@
       <groupId>cascading</groupId>
       <artifactId>cascading-hadoop</artifactId>
     </dependency>
-    <dependency>
-      <groupId>cascading</groupId>
-      <artifactId>cascading-xml</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -252,12 +252,6 @@
         <version>${cascading.version}</version>
         <scope>provided</scope>
       </dependency>
-      <dependency>
-        <groupId>cascading</groupId>
-        <artifactId>cascading-xml</artifactId>
-        <version>${cascading.version}</version>
-        <scope>provided</scope>
-      </dependency>
 
       <!-- scalding -->
       <dependency>


### PR DESCRIPTION
There were no code references to material within the cascading-xml artifact, so I've removed it.

Tested with `mvn clean && mvn install` successfully.
