### PR TITLE
Updates default ScriptStatusServer port from 8080 to random

### DIFF
--- a/common/src/main/java/com/twitter/ambrose/server/ScriptStatusServer.java
+++ b/common/src/main/java/com/twitter/ambrose/server/ScriptStatusServer.java
@@ -70,13 +70,13 @@ public class ScriptStatusServer implements Runnable {
    */
   public static final String PORT_PARAM = "ambrose.port";
   /**
-   * Default port on which to bind HTTP server.
-   */
-  public static final String PORT_DEFAULT = "8080";
-  /**
    * Value of {@link #PORT_PARAM} used to signal a random port should be used.
    */
   public static final String PORT_RANDOM = "random";
+  /**
+   * Default port on which to bind HTTP server.
+   */
+  public static final String PORT_DEFAULT = PORT_RANDOM;
   private static final Logger LOG = LoggerFactory.getLogger(ScriptStatusServer.class);
   private final WorkflowIndexReadService workflowIndexReadService;
   private final StatsReadService<Job> statsReadService;


### PR DESCRIPTION
Most often a random port is what is most appropriate.

End users of the embedded mode for scalding have forgotten to specify a port override and had their scalding invocation fail due to port 8080 conflict. Defaulting to random port should help avoid this type of common failure.
